### PR TITLE
Fix incorrect variable size guess in BroadcastTextVOState.

### DIFF
--- a/definitions/BroadcastTextVOState.dbd
+++ b/definitions/BroadcastTextVOState.dbd
@@ -5,4 +5,4 @@ int SoundStateID?
 LAYOUT 0E5592C9
 BUILD 8.0.1.26715
 $noninline,id$ID<32>
-SoundStateID<32>[2]
+SoundStateID<8>[2]


### PR DESCRIPTION
<simca> our structure for BroadcastTextVOStyle is wrong.
<simca> it was one of those rare DB2s that isn't in the exe and because of compression, we never knew the size of its variables
<simca> we guessed it was int32[2]
<simca> but Blizzard has actually hotfixed this db2 (that doesn't exist in the game's knowledge, so the data is completely pointless) recently
<simca> and DBCache uses real, uncompressed size. int32[2] is too large. the record size in DBCache for that table is not big enough to accommodate 2 int32s.
<simca> uint16[2] works
<simca> uint8[2] is the proper one though.
<simca> we would have noticed this actually lol, the data for the 27026 db2 doesn't make any sense as anything else, looks like blizzard's serializer decided to do the 'pad with garbage' thing and uint8[2] is the only thing that kills the padding