### PR TITLE
ContentTuning: Rename ExpansionLevel to ExpansionID

### DIFF
--- a/definitions/ContentTuning.dbd
+++ b/definitions/ContentTuning.dbd
@@ -5,7 +5,7 @@ int MaxLevel
 int MinLevel
 int<ExpectedStatMod::ID> ExpectedStatModID // moved to table ContentTuningXExpected
 int DifficultyESMID
-int ExpansionLevel?
+int ExpansionID
 int LowerBoundSemantics? // when reading MinLevel, modify as per 0: +0, 1: +1, 2: +server's expansion's min level
 int UpperBoundSemantics? // independent of Flags&2, when reading MaxLevel, modify as per 0: +0, 1: +1, 2: +server's expansion's max level
 int Field_9_0_1_34490_007?
@@ -85,13 +85,13 @@ $id$ID<32>
 MinLevel<32>
 MaxLevel<32>
 Flags<32>
-ExpansionLevel<32>
+ExpansionID<32>
 
 LAYOUT B496B217
 BUILD 9.0.1.33978, 9.0.1.34003, 9.0.1.34081, 9.0.1.34098, 9.0.1.34137, 9.0.1.34199, 9.0.1.34278, 9.0.1.34324, 9.0.1.34365, 9.0.1.34392
 $id$ID<32>
 Flags<32>
-ExpansionLevel<32>
+ExpansionID<32>
 MinLevel<32>
 MaxLevel<32>
 LowerBoundSemantics<32>
@@ -101,7 +101,7 @@ LAYOUT 1BDC59D4
 BUILD 9.0.1.34490
 $id$ID<32>
 Flags<32>
-ExpansionLevel<32>
+ExpansionID<32>
 MinLevel<32>
 MaxLevel<32>
 LowerBoundSemantics<32>
@@ -112,7 +112,7 @@ LAYOUT EB95D5A2
 BUILD 9.0.1.34615
 $id$ID<32>
 Flags<32>
-ExpansionLevel<32>
+ExpansionID<32>
 MinLevel<32>
 MaxLevel<32>
 LowerBoundSemantics<32>
@@ -123,7 +123,7 @@ LAYOUT B6BB9E09
 BUILD 9.0.1.34714, 9.0.1.34821, 9.0.1.34902, 9.0.1.34972, 9.0.1.35078, 9.0.1.35167, 9.0.1.35213, 9.0.1.35256, 9.0.1.35282, 9.0.1.35360, 9.0.1.35432, 9.0.1.35482, 9.0.1.35522
 $id$ID<32>
 Flags<32>
-ExpansionLevel<32>
+ExpansionID<32>
 MinLevel<32>
 MaxLevel<32>
 LowerBoundSemantics<32>
@@ -136,7 +136,7 @@ BUILD 9.0.2.35854, 9.0.2.35938
 BUILD 9.0.1.35598, 9.0.1.35679, 9.0.1.35707, 9.0.1.35755, 9.0.1.35789, 9.0.1.35828, 9.0.1.35853, 9.0.1.35897, 9.0.1.35917, 9.0.1.35944, 9.0.1.35989, 9.0.1.36021, 9.0.1.36036, 9.0.1.36074, 9.0.1.36131, 9.0.1.36163, 9.0.1.36200, 9.0.1.36216, 9.0.1.36228, 9.0.1.36230, 9.0.1.36247, 9.0.1.36272, 9.0.1.36286, 9.0.1.36322, 9.0.1.36372, 9.0.1.36492, 9.0.1.36577
 $id$ID<32>
 Flags<32>
-ExpansionLevel<32>
+ExpansionID<32>
 MinLevel<32>
 MaxLevel<32>
 LowerBoundSemantics<32>
@@ -152,7 +152,7 @@ BUILD 9.0.5.37503, 9.0.5.37623, 9.0.5.37705, 9.0.5.37774, 9.0.5.37844, 9.0.5.378
 BUILD 9.0.2.35978, 9.0.2.36037, 9.0.2.36086, 9.0.2.36165, 9.0.2.36206, 9.0.2.36267, 9.0.2.36294, 9.0.2.36401, 9.0.2.36512, 9.0.2.36532, 9.0.2.36599, 9.0.2.36639, 9.0.2.36665, 9.0.2.36671, 9.0.2.36710, 9.0.2.36734, 9.0.2.36751, 9.0.2.36753, 9.0.2.36839, 9.0.2.36949, 9.0.2.37106, 9.0.2.37130, 9.0.2.37142, 9.0.2.37176, 9.0.2.37415, 9.0.2.37474
 $id$ID<32>
 Flags<32>
-ExpansionLevel<32>
+ExpansionID<32>
 MinLevel<32>
 MaxLevel<32>
 LowerBoundSemantics<32>
@@ -168,7 +168,7 @@ BUILD 9.1.5.39977, 9.1.5.40071, 9.1.5.40078, 9.1.5.40196, 9.1.5.40290, 9.1.5.403
 BUILD 9.1.0.38549, 9.1.0.38600, 9.1.0.38627, 9.1.0.38709, 9.1.0.38783, 9.1.0.38802, 9.1.0.38872, 9.1.0.38950, 9.1.0.39015, 9.1.0.39069, 9.1.0.39121, 9.1.0.39136, 9.1.0.39172, 9.1.0.39185, 9.1.0.39226, 9.1.0.39229, 9.1.0.39262, 9.1.0.39282, 9.1.0.39289, 9.1.0.39291, 9.1.0.39318, 9.1.0.39335, 9.1.0.39413, 9.1.0.39427, 9.1.0.39497, 9.1.0.39498, 9.1.0.39584, 9.1.0.39617, 9.1.0.39653, 9.1.0.39804, 9.1.0.40000, 9.1.0.40120, 9.1.0.40443, 9.1.0.40593, 9.1.0.40725
 $noninline,id$ID<32>
 Flags<32>
-ExpansionLevel<32>
+ExpansionID<32>
 MinLevel<32>
 MaxLevel<32>
 LowerBoundSemantics<32>


### PR DESCRIPTION
We usually name it ExpansionID in all other structures.
Let's keep it this way :D