### PR TITLE
WIP: add dbd_to_mysql.py script for MySQL schema generation

### DIFF
--- a/code/Python/dbd_to_mysql.py
+++ b/code/Python/dbd_to_mysql.py
@@ -1,0 +1,220 @@
+#! /usr/bin/env python3
+# This is a kind of janky script to generte a mostly reasonable MySQL schema
+# for given DBDs and build, including appropriate indexes and foreign keys.
+# The way the bundled dbd library structures things makes this a bit more
+# irritating than it could otherwise be.
+#
+# General usage: ./dbd_to_mysql.py | mysql -u username
+#
+# I'm not particularly proud of most of this code.  --A
+
+import argparse
+import sys
+from typing import Dict, List, Set
+
+import dbd
+
+from ppretty import ppretty
+
+
+def errout(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+# Look through all our tables and find columns that are used as a reference
+# for a foreign key, so that we can add an index on them.
+def get_fk_cols(dbds: Dict[str, dbd.dbd_file]) -> Dict[str, bool]:
+    fks: Dict[str, bool] = {}
+
+    for _, data in dbds.items():
+        for coldata in data.columns:
+            if coldata.foreign:
+                # FIXME: Maybe use a tuple as a key instead
+                key = f"{coldata.foreign.table}.{coldata.foreign.column}"
+                fks[f"{key}"] = True
+
+    return fks
+
+
+# For a given table, find the columns that are actually present in a speciifc
+# build (specified as a build number)
+def get_build_cols(dbd_data: dbd.dbd_file, use_build: int) -> List[str]:
+    for definition in dbd_data.definitions:
+        for build in definition.builds:
+            if getattr(build, "build", None) == use_build:
+                return [e.column for e in definition.entries]
+
+    return []
+
+
+# Generate a list of the columns actually present in a specific build for
+# every table in our dataset.
+def getbuildcols(dbds: Dict[str, dbd.dbd_file], use_build: int) -> Dict[str, Set[str]]:
+    buildcols: Dict[str, Set[str]] = {}
+
+    for table, data in dbds.items():
+        bc = set(get_build_cols(data, use_build))
+
+        if len(bc) > 0:
+            buildcols[table] = bc
+
+    return buildcols
+
+
+# take a given table's parsed data, a list of foreign keys, and a list of
+# present columns, and generate a bunch of MySQL `CREATE TABLE` statements.
+# Returns a list of statements to be executed in an `ALTER TABLE` after all
+# of the tables are created, since you can't do things like create foreign
+# keys until the tables they reference exist.
+def dumpdbd(dbname: str, table: str, dbd_data: dbd.dbd_file,
+            fkcols: Dict[str, bool], bcols: Dict[str, Set[str]]) -> List[str]:
+    create_lines: List[str] = []  # lines for things we need to create
+    create_idxs: List[str] = []  # lines for indexes
+    deferred: List[str] = []  # lines to execute in an `ALTER` at the very end
+
+    # a table that has no columns in the current build doesn't exist in the
+    # current build
+    if table not in bcols:
+        return []
+
+    table_cols = {column.name for column in dbd_data.columns}
+    remaining_cols = table_cols.intersection(bcols[table])
+
+    # If we have no columns left after we filter out what's not present
+    # in this build, warn and do nothing.
+    if len(remaining_cols) == 0:
+        errout(f"WARNING: {table} exists in this build, but needed columns don't exist?!")
+        return []
+
+    # Not sure everything is guaranteed to have a PK, so add one of our
+    # own if there's not an ID column
+    if "ID" not in remaining_cols:
+        create_lines.append("  _id INT UNSIGNED NOT NULL")
+
+    # Iterate through all the parsed columns (the parser will generate a
+    # complete set, regardless of whether they exist in a given build)
+    for column in dbd_data.columns:
+        # skip columns not in this build
+        if column.name not in remaining_cols:
+            continue
+
+        # Create an index for FK-referenced columns (except for the PK, which
+        # gets handled separately). We're going to keep these separately and
+        # add them at the end of the `CREATE`
+        if column.name != "ID" and f"{table}.{column.name}" in fkcols:
+            create_idxs.append(column.name)
+
+        if column.type == "int":
+            create_lines.append(f"  `{column.name}` INT UNSIGNED")
+        elif column.type == "float":
+            create_lines.append(f"  `{column.name}` FLOAT")
+        elif column.type in ["string", "locstring"]:
+            create_lines.append(f"  `{column.name}` MEDIUMTEXT")
+        else:
+            errout(f"WARNING: Unknown type {column.type} for {table}.{column.name}")
+
+    # save all the indexes for the end of the `CREATE`
+    if "ID" in remaining_cols:
+        create_lines.append("  PRIMARY KEY(ID)")
+    else:
+        create_lines.append("  PRIMARY KEY (_id)")
+
+    for idx in create_idxs:
+        create_lines.append(f"  INDEX `{idx}_idx` (`{idx}`)")
+
+    # Generate statements for appropriate foreign keys, which will be returned
+    # from this function to be added at the end after all the tables have been
+    # created.
+    for column in dbd_data.columns:
+        if column.name not in remaining_cols:
+            continue
+
+        if column.foreign:
+            t = str(column.foreign.table)
+            c = str(column.foreign.column)
+
+            # Don't complain about the FileData table not existing, since
+            # everything just uses FDIDs directly now and this FK is still
+            # everywhere because FK info isn't versioned in the dbd defs
+            if t == "FileData":
+                continue
+
+            # This was an across the board change, just Make It Work™
+            if t == "SoundEntries":
+                t = "SoundKit"
+
+            # Make sure the destination table of the FK exists in this build
+            if t not in bcols:
+                errout(
+                    f"WARNING: Foreign key for {table}.{column.name} references non-existent table {t}")
+                continue
+
+            # Make sure the dsestination column of the FK exists in this build
+            if c not in bcols[t]:
+                errout(
+                    f"WARNING: Foreign key {table}.{column.name} references non-existent column {t}.{c}")
+                continue
+
+            deferred.append(
+                f"  ADD CONSTRAINT `{table}_{column.name}` FOREIGN KEY (`{column.name}`) REFERENCES `{dbname}`.`{t}` (`{c}`)")
+
+    # Generate the actual `CREATE` statement
+    print(f"\nCREATE TABLE IF NOT EXISTS `{dbname}`.`{table}` (")
+    print(",\n".join(create_lines))
+    print(");")
+
+    return deferred
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--definitions", dest="definitions", type=str, action='store',
+        default="../../definitions", help="location of .dbd files")
+    parser.add_argument(
+        "--build", dest="build", type=int, default=41488,
+        help="build number (and only build number) to use for parsing")
+    parser.add_argument(
+        "--dbname", dest="dbname", type=str, default="wowdbd",
+        help="name of MySQL database to generate create statements for")
+
+    # --only is disabled for now, since using it will cause FKs to be wrong
+    # if it's used to try to generate an updated schema w/o parsing everything
+    # parser.add_argument(
+    #     "--only", dest="only", type=str, action='append',
+    #     help="parse only these tables")
+
+    args = parser.parse_args()
+
+    # dbds = {}
+    # if args.only:
+    #   for table in args.only:
+    #     dbds[table] = dbd.parse_dbd_file(os.path.join(args.definitions, "{}{}".format(table, dbd.file_suffix)))
+    # else:
+    #   dbds = dbd.parse_dbd_directory(args.definitions)
+
+    dbds = dbd.parse_dbd_directory(args.definitions)
+
+    fkcols = get_fk_cols(dbds)  # foreign key columns
+    bcols = getbuildcols(dbds, args.build)  # columns for specific build
+
+    deferred = {}  # deferred statements to add to `ALTER` at the end
+
+    # No in-place updates -- just drop and recreate the entire database
+    print(f"DROP DATABASE IF EXISTS {args.dbname};")
+    print(f"CREATE DATABASE {args.dbname};")
+
+    for table, data in dbds.items():
+        deferred[table] = dumpdbd(args.dbname, table, data, fkcols, bcols)
+
+    for table, lines in deferred.items():
+        if len(lines) > 0:
+            print(f"\nALTER TABLE `{args.dbname}`.`{table}`")
+            print(",\n".join(lines))
+            print(";")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/code/Python/dbdwrapper.py
+++ b/code/Python/dbdwrapper.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+# simplify the results of parsing a dbd w/ the dbd parser library
+import dataclasses
+import os
+import re
+import sys
+from dataclasses import dataclass
+from typing import (Any, Dict, List, Literal, Optional, Set, Tuple, Type,
+                    TypeVar, Union)
+
+import dbd
+from ppretty import ppretty
+
+BuildIdOrTuple = Union['BuildId', Tuple[int, int, int, int]]
+
+@dataclass(init=True, repr=True, eq=True, frozen=True)
+class BuildId:
+    major: int
+    minor: int
+    patch: int
+    build: int
+
+    @classmethod
+    def from_dbd(cls, src: dbd.build_version) -> 'BuildId':
+        return cls(
+            major=src.major,
+            minor=src.minor,
+            patch=src.patch,
+            build=src.build
+        )
+
+    @classmethod
+    def from_tuple(cls, src: Tuple[int, int, int, int]) -> 'BuildId':
+        return cls(*src)
+
+    @classmethod
+    def from_string(cls, src: str) -> 'BuildId':
+        if not re.match(r'^\d+\.\d+\.\d+\.\d+$', src):
+            raise ValueError(f"Invalid build id string: {src}")
+
+        major, minor, patch, build = src.split('.')
+        return cls(
+            major=int(major),
+            minor=int(minor),
+            patch=int(patch),
+            build=int(build)
+        )
+
+    @staticmethod
+    def build_compare(buildid1: 'BuildId', buildid2: 'BuildId') -> int:
+        if buildid1.major != buildid2.major:
+            return buildid1.major - buildid2.major
+        if buildid1.minor != buildid2.minor:
+            return buildid1.minor - buildid2.minor
+        if buildid1.patch != buildid2.patch:
+            return buildid1.patch - buildid2.patch
+        return buildid1.build - buildid2.build
+
+    # def __eq__(self, other: object) -> bool:
+    #     if not isinstance(other, BuildId) and not isinstance(other, tuple):
+    #         return NotImplemented
+
+    #     if isinstance(other, tuple):
+    #         other = BuildId(*other)
+
+    #     return BuildId.build_compare(self, other) == 0
+
+    def __lt__(self, other: BuildIdOrTuple) -> bool:
+        if not isinstance(other, BuildId):
+            other = BuildId(*other)
+
+        return BuildId.build_compare(self, other) < 0
+
+    def __gt__(self, other: BuildIdOrTuple) -> bool:
+        if not isinstance(other, BuildId):
+            other = BuildId(*other)
+
+        return BuildId.build_compare(self, other) > 0
+
+    def __le__(self, other: BuildIdOrTuple) -> bool:
+        if not isinstance(other, BuildId):
+            other = BuildId(*other)
+
+        return BuildId.build_compare(self, other) <= 0
+
+    def __ge__(self, other: BuildIdOrTuple) -> bool:
+        if not isinstance(other, BuildId):
+            other = BuildId(*other)
+
+        return BuildId.build_compare(self, other) >= 0
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}.{self.build}"
+
+
+BuildIdOrRange = Union[dbd.build_version, Tuple[dbd.build_version, dbd.build_version]]
+
+@dataclass(init=True, repr=True, frozen=True)
+class BuildIdRange:
+    min: BuildId
+    max: BuildId
+
+    def __contains__(self, item: BuildId) -> bool:
+        return self.min <= item <= self.max
+
+    def __str__(self) -> str:
+        return f"{self.min}-{self.max}"
+
+    @classmethod
+    def from_dbd(cls, build: BuildIdOrRange) -> 'BuildIdRange':
+        if isinstance(build, dbd.build_version):
+            bb = BuildId.from_dbd(build)
+            r = cls(bb, bb)
+        elif isinstance(build, tuple):
+            bb = BuildId.from_dbd(build[0])
+            bbb = BuildId.from_dbd(build[1])
+            r = cls(bb, bbb)
+
+        return r
+
+
+
+from collections import UserDict, UserList
+
+
+# a build id dict that you can retrieve from via specific build number.
+# works similarly to https://stackoverflow.com/a/39358140/9404062
+class DbdBuilds(UserDict[BuildIdRange, 'DbdVersionedCols']):
+    # FIXME: consider using 'bisect' for faster lookups
+    # (see https://stackoverflow.com/a/39358118/9404062)
+    def __contains__(self, key: object) -> bool:
+        # if it's a range, behave like a normal dict
+        if isinstance(key, BuildIdRange):
+            if key in self.data:
+                return True
+            else:
+                return False
+
+        # if a specific version (or a string that might be one), check
+        # to see if there's a range
+        if isinstance(key, str) or isinstance(key, BuildId):
+            try:
+                self.__getitem__(key)
+                return True
+            except KeyError:
+                return False
+
+        # else
+        return False
+
+    def __getitem__(self, key: object) -> 'DbdVersionedCols':
+        # FIXME: wrong
+        if isinstance(key, str):
+            key = BuildId.from_dbd(dbd.build_version(key))
+
+        # print(f"resolving for key: {key}")
+        if isinstance(key, BuildId):
+            for k, v in self.data.items():
+                # print(f"checking key vs {k} ")
+                if key in k:
+                    return v
+
+        raise KeyError(key)
+        # return None
+
+    @classmethod
+    def from_dbd(cls, src: List[dbd.definitions], definitions: 'DbdColumnDefs') -> 'DbdBuilds':
+        dbd_builds = cls()
+
+        for dbd_def in src:
+            # get our versioned column list built once per def
+            c = DbdVersionedCols.from_dbd(dbd_def.entries, definitions)
+
+            # Now add all the builds, pointing at this specific def
+            for build in dbd_def.builds:
+                b = BuildIdRange.from_dbd(build)
+                dbd_builds[b] = c
+
+        # print(f"returning: {dbd_builds}")
+        return dbd_builds
+
+
+@dataclass(init=True, repr=True)
+class DbdForeignKey:
+    table: str
+    column: str
+
+
+# holds info from dbd_file.columns, which is the global information for
+# columns in the database. We'll reference this a bunch when building
+# other structures
+@dataclass(init=True, repr=True)
+class DbdColumnDef:
+    name: str
+    type: Literal["string", "locstring", "int", "float"]
+    is_confirmed_name: bool
+    comment: Optional[str] = None
+    fk: Optional[DbdForeignKey] = None
+
+    @classmethod
+    def from_dbd(cls, src: dbd.column_definition):
+        return cls(
+            name=src.name,
+            type=src.type,
+            is_confirmed_name=src.is_confirmed_name,
+            comment=src.comment,
+            fk=None if not src.foreign else DbdForeignKey(
+                table=str(src.foreign.table),
+                column=str(src.foreign.column)
+            )
+        )
+
+
+class DbdColumnDefs(UserDict[str, DbdColumnDef]):
+    @classmethod
+    def from_dbd(cls, src: List[dbd.column_definition]) -> 'DbdColumnDefs':
+        defs = cls()
+        for d in src:
+            defs[d.name] = DbdColumnDef.from_dbd(d)
+
+        return defs
+
+
+@dataclass(init=True, repr=True)
+class DbdVersionedCol:
+    name: str
+    definition: DbdColumnDef
+    annotation: Set[str] = dataclasses.field(default_factory=set)
+    array_size: Optional[int] = None
+    comment: Optional[str] = None
+    int_width: Optional[int] = None
+    is_unsigned: bool = True
+
+    @classmethod
+    def from_dbd(cls, src: dbd.definition_entry, definition: DbdColumnDef) -> 'DbdVersionedCol':
+        return cls(
+            name=src.column,
+            definition=definition,
+            annotation=set(src.annotation),
+            array_size=src.array_size,
+            comment=src.comment,
+            int_width=src.int_width,
+            is_unsigned=src.is_unsigned
+        )
+
+
+class DbdVersionedCols(UserDict[str, DbdVersionedCol]):
+    @classmethod
+    def from_dbd(cls, src: List[dbd.definition_entry], definitions: DbdColumnDefs) -> 'DbdVersionedCols':
+        cols = cls()
+        for d in src:
+            cols[d.column] = DbdVersionedCol.from_dbd(d, definitions[d.column])
+
+        return cols
+
+
+# @dataclass(init=True, repr=True)
+# class DbdVersionDef:
+#     builds: List[BuildId]
+#     comments: List[str] = dataclasses.field(default_factory=list)
+
+
+# def dbdparse(filename: str) -> None:
+#     with open(filename) as file:
+#         lines = file.readlines()
+
+#     lines = [line.rstrip() for line in lines]
+#     lines = [line for line in lines if line]
+
+#     # print(ppretty(lines))
+#     parse_cols(lines)
+
+@dataclass(init=True, repr=True)
+class DbdFileData:
+    columns: DbdColumnDefs
+    definitions: DbdBuilds
+
+    @classmethod
+    def from_dbd(cls, src: dbd.dbd_file):
+        definitions = DbdColumnDefs.from_dbd(src.columns)
+        return cls(
+            columns=definitions,
+            definitions=DbdBuilds.from_dbd(src.definitions, definitions)
+        )
+
+# def dbds(dbd_file: dbd.dbd_file) -> 'DBData':
+#     pass
+
+
+DbdVersionedView = Dict[str, DbdVersionedCols]
+class DbdDirectory(UserDict[str, DbdFileData]):
+    def get_view(self, build: BuildIdOrTuple) -> DbdVersionedView:
+        view: DbdVersionedView = {}
+        if isinstance(build, tuple):
+            build = BuildId.from_tuple(build)
+
+        for table, tabledef in self.data.items():
+            builds = tabledef.definitions
+            if build in builds:
+                view[table] = builds[build]
+
+        return view
+
+def parse_dbd_file(filename: str) -> DbdFileData:
+    dbf = dbd.parse_dbd_file(filename)
+    return DbdFileData.from_dbd(dbf)
+
+
+def parse_dbd_directory(path: str) -> DbdDirectory:
+    dbds = DbdDirectory()
+
+    for file in os.listdir(path):
+        if file.endswith(".dbd"):
+            dbds[file[:-len(".dbd")]] = parse_dbd_file(os.path.join(path, file))
+
+    return dbds
+
+# def get_versioned_view(tables: Dict[str, DbdFileData], build: BuildIdOrTuple) -> Dict[str, DbdVersionedCols]:
+#     view: Dict[str, DbdVersionedCols] = {}
+#     if isinstance(build, tuple):
+#         build = BuildId.from_tuple(build)
+
+#     for table, tabledef in tables.items():
+#         builds = tabledef.definitions
+#         if build in builds:
+#             view[table] = builds[build]
+
+#     return view
+
+
+if __name__ == "__main__":
+    # print(b == b)
+    # print(b == (1, 2, 3, 4))
+    # print(b < (1, 2, 3, 4))
+    # print(b <= (1, 2, 3, 4))
+    # print(b < (1, 2, 3, 5))
+    # print(b > (1, 2, 3, 5))
+    # print(b > (1, 2, 3, 4))
+    # print(b >= (1, 2, 3, 4))
+    # print(b > (1, 2, 3, 3))
+
+    # c = BuildId(1, 2, 3, 5)
+    # print(b == c)
+    # print(b < c)
+
+    # print(b == "bob")
+
+    # dbf = dbd.parse_dbd_file("../../defs.mini/Spell.dbd")
+    # f = DbdFileData.from_dbd(dbf)
+    # f = parse_dbd_file("../../defs.mini/Spell.dbd")
+    d = parse_dbd_directory("../../defs.mini")
+    b = BuildId(3, 1, 2, 9768)
+
+    v = d.get_view(b)
+    print(ppretty(v))
+
+    # for t in d.keys():
+    #     print(ppretty(d[t].definitions[b]))
+
+    sys.exit(0)


### PR DESCRIPTION
Generates a seemingly sane MySQL schema for a given build based on WoWDBDDefs
definitions. Unfortunately a bit slowly, because the existing dbd parser takes a bit to
grind the 1000 or so table definitions.

Once the resulting schema is loaded into MySQL, it can then be used by tools like
schemaspy to generate useful ways to browse the db structure (see e.g. https://www.lupine.org/~alinsa/wowdbd/)