### PR TITLE
Fix Iterable import breakage on Python 3.10+

### DIFF
--- a/code/Python/dbd.py
+++ b/code/Python/dbd.py
@@ -250,7 +250,10 @@ class definitions(Grammar):
     def grammar_elem_init(self, sessiondata):
 
         def flatten(lis, rec_depth=0):
-            from collections import Iterable
+            try:
+                from collections.abc import Iterable
+            except ImportError:
+                from collections import Iterable  # Python <3.3 compatibility
             for item in lis:
                 if isinstance(item, Iterable) and not isinstance(item, str):
                     for x in flatten(item):


### PR DESCRIPTION
Abstract base classes were moved to `collections.abc` in Python 3.3 with deprecated aliases made available to keep imports from `collections` still working. Those were removed in 3.10, leading to incompatibility and suffering.

This fix itself is untested, but should just work.