### PR TITLE
Update SpellChainEffects.dbd

### DIFF
--- a/definitions/SpellChainEffects.dbd
+++ b/definitions/SpellChainEffects.dbd
@@ -42,7 +42,6 @@ int Red
 int Green
 int Blue
 int BlendMode
-int Padding_5_3_0_16965_043?
 int RenderLayer
 float TextureLength
 float WavePhase
@@ -125,6 +124,7 @@ Red<8>
 Green<8>
 Blue<8>
 BlendMode<8>
+Padding_4_0_0_11792_044<8>[3] // This is a pure guess based on a fix for 3.3.5. See https://github.com/wowdev/WoWDBDefs/pull/114.
 Combo
 RenderLayer<32>
 
@@ -225,7 +225,8 @@ Alpha<8>
 Red<8>
 Green<8>
 Blue<8>
-BlendMode<32>
+BlendMode<8>
+Padding_4_0_0_11792_044<8>[3]
 Combo
 RenderLayer<32>
 TextureLength
@@ -329,7 +330,7 @@ Red<8>
 Green<8>
 Blue<8>
 BlendMode<8>
-Padding_5_3_0_16965_043<8>[3]
+Padding_4_0_0_11792_044<8>[3]
 RenderLayer<32>
 TextureLength
 WavePhase
@@ -381,7 +382,7 @@ Red<8>
 Green<8>
 Blue<8>
 BlendMode<8>
-Padding_5_3_0_16965_043<8>[3]
+Padding_4_0_0_11792_044<8>[3]
 RenderLayer<32>
 TextureLength
 WavePhase

--- a/definitions/SpellChainEffects.dbd
+++ b/definitions/SpellChainEffects.dbd
@@ -225,7 +225,7 @@ Alpha<8>
 Red<8>
 Green<8>
 Blue<8>
-BlendMode<8>
+BlendMode
 Combo
 RenderLayer<32>
 TextureLength

--- a/definitions/SpellChainEffects.dbd
+++ b/definitions/SpellChainEffects.dbd
@@ -177,6 +177,7 @@ Red<8>
 Green<8>
 Blue<8>
 BlendMode<8>
+Padding_4_0_0_11792_044<8>[3] // This is a pure guess based on a fix for 3.3.5. See https://github.com/wowdev/WoWDBDefs/pull/114.
 Combo
 RenderLayer<32>
 TextureLength
@@ -226,7 +227,7 @@ Red<8>
 Green<8>
 Blue<8>
 BlendMode<8>
-Padding_4_0_0_11792_044<8>[3]
+Padding_4_0_0_11792_044<8>[3] // This is a pure guess based on a fix for 3.3.5. See https://github.com/wowdev/WoWDBDefs/pull/114.
 Combo
 RenderLayer<32>
 TextureLength

--- a/definitions/SpellChainEffects.dbd
+++ b/definitions/SpellChainEffects.dbd
@@ -225,7 +225,7 @@ Alpha<8>
 Red<8>
 Green<8>
 Blue<8>
-BlendMode
+BlendMode<32>
 Combo
 RenderLayer<32>
 TextureLength


### PR DESCRIPTION
BlendMode size is 4 bytes.

This is accessing m_Combo and does not line up with WoWDBDefs.

```cpp
            (iVar7 = CLightning::DecodeChainEffectsID
                               (*(undefined4 *)(*(int *)(spellChainEffectsEntry + 0xa4) + local_2c))
```