### PR TITLE
1.3.1.4297 - missing faction def

### DIFF
--- a/definitions/Faction.dbd
+++ b/definitions/Faction.dbd
@@ -55,7 +55,7 @@ ReputationBase<32>[4]
 ParentFactionID<32>
 Name_lang
 
-BUILD 1.2.0.4147-1.3.0.4284
+BUILD 1.2.0.4147-1.3.1.4297
 $id$ID<32>
 ReputationIndex<32>
 ReputationRaceMask<32>[4]


### PR DESCRIPTION
Fixes missing definition for faction.dbc in build 1.3.1.4297

Note: 1.3.2.4298 is also missing, but I don't have that client.
