### PR TITLE
name some 11.0.0.54210 fields

### DIFF
--- a/definitions/CurrencyCategory.dbd
+++ b/definitions/CurrencyCategory.dbd
@@ -3,7 +3,7 @@ int ID
 int Flags
 locstring Name_lang
 int ExpansionID
-int Field_11_0_0_54210_003?
+int<CurrencyCategory::ID> ParentCategoryID?
 
 BUILD 6.0.1.18179
 BUILD 4.0.0.11792
@@ -100,4 +100,4 @@ $noninline,id$ID<32>
 Name_lang
 Flags<32>
 ExpansionID<u8>
-Field_11_0_0_54210_003<32>
+ParentCategoryID<32>

--- a/definitions/CurrencyTypes.dbd
+++ b/definitions/CurrencyTypes.dbd
@@ -22,7 +22,7 @@ int RechargingAmountPerCycle?
 int RechargingCycleDurationMS?
 int Field_3_4_3_51278_010?
 int Field_4_4_0_54137_011?
-float Field_11_0_0_54210_016?
+float WarbondTransferPercentage?
 
 LAYOUT 7A943838
 BUILD 2.5.2.39570, 2.5.2.39618, 2.5.2.39658, 2.5.2.39688, 2.5.2.39757, 2.5.2.39801, 2.5.2.39832, 2.5.2.39926, 2.5.2.40011, 2.5.2.40045, 2.5.2.40203, 2.5.2.40260, 2.5.2.40422, 2.5.2.40488, 2.5.2.40617, 2.5.2.40892, 2.5.2.41446, 2.5.2.41510
@@ -444,5 +444,5 @@ AwardConditionID<32>
 MaxQtyWorldStateID<32>
 RechargingAmountPerCycle<u32>
 RechargingCycleDurationMS<u32>
-Field_11_0_0_54210_016
+WarbondTransferPercentage
 Flags<32>[2]

--- a/definitions/ProfessionExpansion.dbd
+++ b/definitions/ProfessionExpansion.dbd
@@ -1,12 +1,12 @@
 COLUMNS
-int Field_11_0_0_54210_000?
+int ID?
 int<SkillLine::ID> SkillLineID?
 int<Spell::ID> RecraftSpellID?
 int<Profession::ID> ProfessionID?
 
 LAYOUT 686F6887
 BUILD 11.0.0.54210, 11.0.0.54289, 11.0.0.54311
-$id$Field_11_0_0_54210_000<32>
+$id$ID<32>
 SkillLineID<32>
 RecraftSpellID<32>
 $noninline,relation$ProfessionID<32>

--- a/definitions/SpellMisc.dbd
+++ b/definitions/SpellMisc.dbd
@@ -19,7 +19,7 @@ int<ContentTuning::ID> ContentTuningID
 int<PlayerCondition::ID> ShowFutureSpellPlayerConditionID
 int SpellVisualScript? // for some reason shipped but if != 0, client errors.
 int ActiveSpellVisualScript?
-int Field_11_0_0_54210_004?
+int<SpellDuration::ID> PvPDurationIndex?
 
 LAYOUT AAE9BEC0
 BUILD 2.5.1.38043, 2.5.1.38061, 2.5.1.38093, 2.5.1.38118, 2.5.1.38119, 2.5.1.38169, 2.5.1.38225, 2.5.1.38285, 2.5.1.38339, 2.5.1.38364, 2.5.1.38401, 2.5.1.38453, 2.5.1.38502, 2.5.1.38521, 2.5.1.38537, 2.5.1.38548, 2.5.1.38561, 2.5.1.38598, 2.5.1.38644, 2.5.1.38677, 2.5.1.38692, 2.5.1.38707, 2.5.1.38739, 2.5.1.38741, 2.5.1.38757, 2.5.1.38835, 2.5.1.38892, 2.5.1.38921, 2.5.1.38988, 2.5.1.39170, 2.5.1.39399, 2.5.1.39475, 2.5.1.39603, 2.5.1.39640
@@ -407,7 +407,7 @@ Attributes<32>[15]
 DifficultyID<u8>
 CastingTimeIndex<u16>
 DurationIndex<u16>
-Field_11_0_0_54210_004<u16>
+PvPDurationIndex<u16>
 RangeIndex<u16>
 SchoolMask<u8>
 Speed


### PR DESCRIPTION
- CurrencyCategory::ParentCategoryID is a guess based on the fact it would make sense for all old expansion currencies to move under "Legacy," but I haven't confirmed this new organization in the client yet.
- CurrencyTypes::WarbondTransferPercentage is based on Blizzard stating that some currencies will have a "Transfer" button in the UI to send them to another character and that some currencies will be penalized during transfer (https://worldofwarcraft.blizzard.com/en-us/news/24061008/the-war-within-warbands-preview). This also needs to be confirmed still.
- SpellMisc::PvPDurationIndex matches the known PvP duration for every spell I checked. Some examples from the Mage class are Polymorph (118) at 6 seconds, Slow (31589) at 8 seconds, and Dragon's Breath (31661) at 3 seconds.