### PR TITLE
Fix foreign key DungeonMap::ParentWorldMapID incorrectly pointing to AreaTable::ID instead of WorldMapArea::ID

### DIFF
--- a/definitions/DungeonMap.dbd
+++ b/definitions/DungeonMap.dbd
@@ -4,7 +4,7 @@ int<Map::ID> MapID
 int FloorIndex
 float Min
 float Max
-int<AreaTable::ID> ParentWorldMapID
+int<WorldMapArea::ID> ParentWorldMapID
 int Flags
 int RelativeHeightIndex
 float MinX


### PR DESCRIPTION
Fix foreign key DungeonMap::ParentWorldMapID incorrectly pointing to AreaTable::ID instead of WorldMapArea::ID.

### Sources
1. https://trinitycore.info/en/files/DBC/335/dungeonmap
2. Simply looking at the data.
Example: [Icecrown citadel (MapID=631)](https://wago.tools/db2/DungeonMap?build=8.0.1.26321&filter[MapID]=631&page=1) lists 492 as ParentWorldMapID. [492 in AreaTable::ID](https://wago.tools/db2/AreaTable?build=8.0.1.26321&filter[ID]=exact%3A492&page=1) is Raven Hill Cemetery in Duskwood while [492 in WorldMapArea::ID](https://wago.tools/db2/WorldMapArea?build=8.0.1.26321&filter[ID]=492&page=1) is IcecrownGlacier