### PR TITLE
Release definitions (DBD/JSON/XML/BDBD) upon a definition/manifest change

### DIFF
--- a/.github/workflows/release_defs.yml
+++ b/.github/workflows/release_defs.yml
@@ -1,0 +1,72 @@
+name: Compile & release definitions
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      -  definitions/**
+      -  manifest.json
+jobs:
+  compile-bdbd:
+    name: Build BDBD
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set tag name
+      run: echo "NOW=$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
+    - name: Create tag
+      uses: actions/github-script@v5
+      with:
+        script: |
+          github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ env.NOW }}',
+              sha: context.sha
+          })
+    - name: Checkout repo
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 8.0.x
+    - name: Compile BDBD file with DBDefsConverter
+      run: mkdir $PWD/tmp && dotnet run --project $PWD/code/C#/DBDefsConverter --configuration Release -- $PWD/definitions $PWD/tmp/all.bdbd bdbd
+    - name: Compile JSON DBDs with DBDefsConverter
+      run: dotnet run --project $PWD/code/C#/DBDefsConverter --configuration Release -- $PWD/definitions $PWD/tmp/json json
+    - name: Compile XML DBDs with DBDefsConverter
+      run: dotnet run --project $PWD/code/C#/DBDefsConverter --configuration Release -- $PWD/definitions $PWD/tmp/xml xml
+    - name: Copy manifest
+      run: cp $PWD/manifest.json $PWD/tmp/manifest.json
+    - name: Archive DBDs
+      uses: thedoctor0/zip-release@main
+      with:
+        directory: $PWD/definitions
+        type: 'zip'
+        filename: $PWD/tmp/dbd.zip
+    - name: Archive JSONs
+      uses: thedoctor0/zip-release@main
+      with:
+        directory: $PWD/tmp/json
+        type: 'zip'
+        filename: $PWD/tmp/json.zip
+    - name: Archive XMLs
+      uses: thedoctor0/zip-release@main
+      with:
+        directory: $PWD/tmp/xml
+        type: 'zip'
+        filename: $PWD/tmp/xml.zip
+    - name: Create Release
+      id: create_release
+      uses: softprops/action-gh-release@v0.1.13
+      with:
+        name: Definitions v${{ env.NOW }}
+        draft: false
+        prerelease: false
+        tag_name: ${{ env.NOW }}    
+        files: |
+            tmp/all.bdbd
+            tmp/dbd.zip
+            tmp/json.zip
+            tmp/xml.zip
+            tmp/manifest.json

--- a/.github/workflows/release_defs.yml
+++ b/.github/workflows/release_defs.yml
@@ -62,11 +62,12 @@ jobs:
       with:
         name: Definitions v${{ env.NOW }}
         draft: false
+        body: Current definitions at time of this release. Only DBD definitions are actively supported. While up-to-date, BDBD/JSON/XML definitions should be considered experimental.
         prerelease: false
         tag_name: ${{ env.NOW }}    
         files: |
-            ${{ github.workspace }}/tmp/all.bdbd
             ${{ github.workspace }}/tmp/dbd.zip
+            ${{ github.workspace }}/tmp/all.bdbd
             ${{ github.workspace }}/tmp/json.zip
             ${{ github.workspace }}/tmp/xml.zip
             ${{ github.workspace }}/tmp/manifest.json

--- a/.github/workflows/release_defs.yml
+++ b/.github/workflows/release_defs.yml
@@ -7,7 +7,7 @@ on:
       -  manifest.json
 jobs:
   compile-bdbd:
-    name: Build BDBD
+    name: Build BDBD/JSON/XML definitions
     runs-on: ubuntu-latest
     steps:
     - name: Set tag name
@@ -31,31 +31,31 @@ jobs:
       with:
         dotnet-version: 8.0.x
     - name: Compile BDBD file with DBDefsConverter
-      run: mkdir $PWD/tmp && dotnet run --project $PWD/code/C#/DBDefsConverter --configuration Release -- $PWD/definitions $PWD/tmp/all.bdbd bdbd
+      run: mkdir ${{ github.workspace }}/tmp && dotnet run --project ${{ github.workspace }}/code/C#/DBDefsConverter --configuration Release -- ${{ github.workspace }}/definitions ${{ github.workspace }}/tmp/all.bdbd bdbd
     - name: Compile JSON DBDs with DBDefsConverter
-      run: dotnet run --project $PWD/code/C#/DBDefsConverter --configuration Release -- $PWD/definitions $PWD/tmp/json json
+      run: dotnet run --project ${{ github.workspace }}/code/C#/DBDefsConverter --configuration Release -- ${{ github.workspace }}/definitions ${{ github.workspace }}/tmp/json json
     - name: Compile XML DBDs with DBDefsConverter
-      run: dotnet run --project $PWD/code/C#/DBDefsConverter --configuration Release -- $PWD/definitions $PWD/tmp/xml xml
+      run: dotnet run --project ${{ github.workspace }}/code/C#/DBDefsConverter --configuration Release -- ${{ github.workspace }}/definitions ${{ github.workspace }}/tmp/xml xml
     - name: Copy manifest
-      run: cp $PWD/manifest.json $PWD/tmp/manifest.json
+      run: cp ${{ github.workspace }}/manifest.json ${{ github.workspace }}/tmp/manifest.json
     - name: Archive DBDs
       uses: thedoctor0/zip-release@main
       with:
-        directory: $PWD/definitions
+        directory: ${{ github.workspace }}/definitions
         type: 'zip'
-        filename: $PWD/tmp/dbd.zip
+        filename: ${{ github.workspace }}/tmp/dbd.zip
     - name: Archive JSONs
       uses: thedoctor0/zip-release@main
       with:
-        directory: $PWD/tmp/json
+        directory: ${{ github.workspace }}/tmp/json
         type: 'zip'
-        filename: $PWD/tmp/json.zip
+        filename: ${{ github.workspace }}/tmp/json.zip
     - name: Archive XMLs
       uses: thedoctor0/zip-release@main
       with:
-        directory: $PWD/tmp/xml
+        directory: ${{ github.workspace }}/tmp/xml
         type: 'zip'
-        filename: $PWD/tmp/xml.zip
+        filename: ${{ github.workspace }}/tmp/xml.zip
     - name: Create Release
       id: create_release
       uses: softprops/action-gh-release@v0.1.13
@@ -65,8 +65,8 @@ jobs:
         prerelease: false
         tag_name: ${{ env.NOW }}    
         files: |
-            tmp/all.bdbd
-            tmp/dbd.zip
-            tmp/json.zip
-            tmp/xml.zip
-            tmp/manifest.json
+            ${{ github.workspace }}/tmp/all.bdbd
+            ${{ github.workspace }}/tmp/dbd.zip
+            ${{ github.workspace }}/tmp/json.zip
+            ${{ github.workspace }}/tmp/xml.zip
+            ${{ github.workspace }}/tmp/manifest.json

--- a/code/C#/DBDefsConverter/Program.cs
+++ b/code/C#/DBDefsConverter/Program.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using static DBDefsLib.Structs;
 
 namespace DBDefsConverter
@@ -23,14 +22,6 @@ namespace DBDefsConverter
             var exportFormat = "json";
             Build exportBuild = null;
 
-            if (args.Length >= 2)
-            {
-                outDir = args[1];
-                if (!Directory.Exists(outDir))
-                {
-                    Directory.CreateDirectory(outDir);
-                }
-            }
 
             if (args.Length == 3)
             {
@@ -44,6 +35,14 @@ namespace DBDefsConverter
                     default:
                         throw new ArgumentException("Export format should be json or xml");
                 }
+            }
+
+            if (args.Length >= 2)
+            {
+                outDir = args[1];
+
+                if (exportFormat != "bdbd" && !Directory.Exists(outDir))
+                    Directory.CreateDirectory(outDir);
             }
 
             if (args.Length == 4)
@@ -254,8 +253,13 @@ namespace DBDefsConverter
             Console.WriteLine("Done, writing BDBD...");
 
             var outputPath = outFile;
-            if (Directory.Exists(outFile))
+            if (!outputPath.EndsWith(".bdbd"))
+            {
                 outputPath = Path.Combine(outFile, "out.bdbd");
+                var outputDir = Path.GetDirectoryName(outputPath);
+                if (!Directory.Exists(outputDir))
+                    Directory.CreateDirectory(outputDir);
+            }
 
             BDBDWriter.Save(dbds, outputPath, tableNameToDBC, tableNameToDB2);
 

--- a/code/C#/DBDefsLib/BDBDWriter.cs
+++ b/code/C#/DBDefsLib/BDBDWriter.cs
@@ -49,7 +49,7 @@ namespace DBDefsLib
                 }
             }
 
-            using (var fs = new FileStream(target, FileMode.Truncate))
+            using (var fs = new FileStream(target, FileMode.Create))
             using (var bw = new BinaryWriter(fs))
             {
                 bw.Write(['B', 'D', 'B', 'D']);


### PR DESCRIPTION
Automated releases of definitions when we change something in `definitions/` or `manifest.json` (or run the action manually), similar to how listfile releases work. Allows for easier updates/downloads for applications needing all DBDs locally (e.g. wow.tools.local), also makes JSON/XML/BDBD defs accessible instead of hidden behind the converter tool.

Releases would look like this: https://github.com/Marlamin/WoWDBDefs/releases/tag/202504081713

(Squash when merging please)